### PR TITLE
add visualstar search to ex search history and evil search history

### DIFF
--- a/evil-visualstar.el
+++ b/evil-visualstar.el
@@ -58,6 +58,11 @@
           (setq evil-ex-search-direction direction)
           (setq evil-ex-search-pattern pattern)
           (evil-ex-search-activate-highlight pattern)
+        ;; update search history unless this pattern equals the
+        ;; previous pattern
+        (unless (equal (car-safe evil-ex-search-history) selection)
+          (push selection evil-ex-search-history))
+        (evil-push-search-history selection (eq direction 'forward))
           (evil-ex-search-next))))))
 
 (defun evil-visualstar/begin-search-forward (beg end)


### PR DESCRIPTION
If we add the visual star search to evil search history, we could call c-r / to paste the ex search history from the registers.

As the evil ex-search-forward-word is also implemented like this.